### PR TITLE
fix: Ensure cleanup of existing Terraform files before initialization

### DIFF
--- a/tf_apply/rules/tf_init.sh
+++ b/tf_apply/rules/tf_init.sh
@@ -17,12 +17,16 @@ fi
 OUT_DIR="$BUILD_WORKSPACE_DIRECTORY/bazel-tf/$TF_DIR"
 mkdir -p "$OUT_DIR"
 
+# Init on a clean TF_DIR
+rm -rf "$PWD/$TF_DIR/.terraform"
+rm "$PWD/$TF_DIR/.terraform.lock.hcl"
+
 # Run terraform init
 $TF_BIN_PATH -chdir="$TF_DIR" init -input=false -plugin-dir="$TF_PLUGINS_DIR"
 
 # remove any existing .terraform and .terraform.lock.hcl files
 rm -rf "$OUT_DIR/.terraform"
-rm -f "$OUT_DIR/.terraform.lock.hcl"
+rm "$OUT_DIR/.terraform.lock.hcl"
 
 # symlink the .terraform directory to the output directory
 ln -s  "$PWD/$TF_DIR/.terraform" "$OUT_DIR/.terraform"


### PR DESCRIPTION
This pull request updates the Terraform initialization script to ensure a cleaner and more predictable setup by explicitly removing certain files and directories before running `terraform init`. The most important changes are:

Terraform initialization cleanup:

* Before running `terraform init`, the script now removes any existing `.terraform` directory and `.terraform.lock.hcl` file from the working Terraform directory to ensure a clean initialization.
* After initialization, the script removes the `.terraform` directory and `.terraform.lock.hcl` file from the output directory, but now uses `rm` instead of `rm -f` for the lock file.