### PR TITLE
fix: Ensure consistent removal of .terraform.lock.hcl files in tf_ini…

### DIFF
--- a/tf_apply/rules/tf_init.sh
+++ b/tf_apply/rules/tf_init.sh
@@ -19,14 +19,14 @@ mkdir -p "$OUT_DIR"
 
 # Init on a clean TF_DIR
 rm -rf "$PWD/$TF_DIR/.terraform"
-rm "$PWD/$TF_DIR/.terraform.lock.hcl"
+rm -rf "$PWD/$TF_DIR/.terraform.lock.hcl"
 
 # Run terraform init
 $TF_BIN_PATH -chdir="$TF_DIR" init -input=false -plugin-dir="$TF_PLUGINS_DIR"
 
 # remove any existing .terraform and .terraform.lock.hcl files
 rm -rf "$OUT_DIR/.terraform"
-rm "$OUT_DIR/.terraform.lock.hcl"
+rm -rf "$OUT_DIR/.terraform.lock.hcl"
 
 # symlink the .terraform directory to the output directory
 ln -s  "$PWD/$TF_DIR/.terraform" "$OUT_DIR/.terraform"


### PR DESCRIPTION
- Fix cleaning up non-existent .terrform files
- add `tf_vars` to define a `bazel.auto.tfvars` file that gets injected into the tf_module during runtime