### PR TITLE
Bugfix: Remove .terraform and .terraform.lock.hcl before creating symlinks

### DIFF
--- a/tf_apply/rules/tf_apply.sh
+++ b/tf_apply/rules/tf_apply.sh
@@ -32,6 +32,9 @@ if [ ! -f "$OUT_DIR/plan.tfplan" ]; then
 fi
 
 # symlink the .terraform directory from the output directory
+# Ensure that any existing .terraform directory or .terraform.lock.hcl file is removed first
+test -d "$TF_DIR/.terraform" && rm -rf "$TF_DIR/.terraform"
+test -f "$TF_DIR/.terraform.lock.hcl" && rm -rf "$TF_DIR/.terraform.lock.hcl"
 ln -sfn "$OUT_DIR/.terraform" "$TF_DIR/.terraform"
 ln -sfn "$OUT_DIR/.terraform.lock.hcl" "$TF_DIR/.terraform.lock.hcl"
 ln -sfn "$OUT_DIR/plan.tfplan" "$TF_DIR/.terraform/plan.tfplan"

--- a/tf_apply/rules/tf_plan.sh
+++ b/tf_apply/rules/tf_plan.sh
@@ -26,6 +26,9 @@ if [ ! -f "$OUT_DIR/.terraform.lock.hcl" ]; then
 fi
 
 # symlink the .terraform directory from the output directory
+# Ensure that any existing .terraform directory or .terraform.lock.hcl file is removed first
+test -d "$TF_DIR/.terraform" && rm -rf "$TF_DIR/.terraform"
+test -f "$TF_DIR/.terraform.lock.hcl" && rm -rf "$TF_DIR/.terraform.lock.hcl"
 ln -sfn "$OUT_DIR/.terraform" "$TF_DIR/.terraform"
 ln -sfn "$OUT_DIR/.terraform.lock.hcl" "$TF_DIR/.terraform.lock.hcl"
 


### PR DESCRIPTION
This avoids provider mismatches when running `plan` or `apply` with an existing `.terraform` folder in the terraform directory.

---

This pull request improves the reliability of symlinking Terraform state and lock files in the `tf_apply` and `tf_plan` scripts. The main change is to ensure that any existing `.terraform` directory or `.terraform.lock.hcl` file in the target directory is removed before creating new symlinks, preventing conflicts or stale state.

Improvements to symlinking logic:

* In both `tf_apply/rules/tf_apply.sh` and `tf_apply/rules/tf_plan.sh`, added checks to remove existing `.terraform` directories and `.terraform.lock.hcl` files in `TF_DIR` before creating symlinks to those resources from `OUT_DIR`. [[1]](diffhunk://#diff-62d2592eb19b8f96486b5f94b617ba95fdaaf8f272429ac5d29e525aa84bf4fbR35-R37) [[2]](diffhunk://#diff-b14fe861c14e0f66e21780e851cc45f4149f056c9f2cecb0e6ea99e0522fae8fR29-R31)