### PR TITLE
fix: avoid creating nested symlinks

### DIFF
--- a/tf_apply/rules/tf_apply.sh
+++ b/tf_apply/rules/tf_apply.sh
@@ -39,4 +39,4 @@ ln -sfn "$OUT_DIR/.terraform" "$TF_DIR/.terraform"
 ln -sfn "$OUT_DIR/.terraform.lock.hcl" "$TF_DIR/.terraform.lock.hcl"
 ln -sfn "$OUT_DIR/plan.tfplan" "$TF_DIR/plan.tfplan"
 
-$TF_BIN_PATH -chdir="$TF_DIR" apply -input=false -auto-approve
+$TF_BIN_PATH -chdir="$TF_DIR" apply -input=false -auto-approve "plan.tfplan"

--- a/tf_apply/rules/tf_apply.sh
+++ b/tf_apply/rules/tf_apply.sh
@@ -37,6 +37,6 @@ test -d "$TF_DIR/.terraform" && rm -rf "$TF_DIR/.terraform"
 test -f "$TF_DIR/.terraform.lock.hcl" && rm -rf "$TF_DIR/.terraform.lock.hcl"
 ln -sfn "$OUT_DIR/.terraform" "$TF_DIR/.terraform"
 ln -sfn "$OUT_DIR/.terraform.lock.hcl" "$TF_DIR/.terraform.lock.hcl"
-ln -sfn "$OUT_DIR/plan.tfplan" "$TF_DIR/.terraform/plan.tfplan"
+ln -sfn "$OUT_DIR/plan.tfplan" "$TF_DIR/plan.tfplan"
 
 $TF_BIN_PATH -chdir="$TF_DIR" apply -input=false -auto-approve

--- a/tf_apply/rules/tf_init.sh
+++ b/tf_apply/rules/tf_init.sh
@@ -19,12 +19,12 @@ mkdir -p "$OUT_DIR"
 rm -rf "$PWD/$TF_DIR/.terraform"
 rm -rf "$PWD/$TF_DIR/.terraform.lock.hcl"
 
-# Run terraform init
-$TF_BIN_PATH -chdir="$TF_DIR" init -input=false -plugin-dir="$TF_PLUGINS_DIR"
-
 # remove any existing .terraform and .terraform.lock.hcl files
 rm -rf "$OUT_DIR/.terraform"
 rm -rf "$OUT_DIR/.terraform.lock.hcl"
+
+# Run terraform init
+$TF_BIN_PATH -chdir="$TF_DIR" init -input=false -plugin-dir="$TF_PLUGINS_DIR"
 
 # symlink the .terraform directory to the output directory
 ln -s  "$PWD/$TF_DIR/.terraform" "$OUT_DIR/.terraform"

--- a/tf_apply/rules/tf_plan.sh
+++ b/tf_apply/rules/tf_plan.sh
@@ -29,10 +29,12 @@ fi
 # Ensure that any existing .terraform directory or .terraform.lock.hcl file is removed first
 test -d "$TF_DIR/.terraform" && rm -rf "$TF_DIR/.terraform"
 test -f "$TF_DIR/.terraform.lock.hcl" && rm -rf "$TF_DIR/.terraform.lock.hcl"
+test -f "$TF_DIR/plan.tfplan" && rm -rf "$TF_DIR/plan.tfplan"
+
 ln -sfn "$OUT_DIR/.terraform" "$TF_DIR/.terraform"
 ln -sfn "$OUT_DIR/.terraform.lock.hcl" "$TF_DIR/.terraform.lock.hcl"
 
-$TF_BIN_PATH -chdir="$TF_DIR" plan -input=false -out=".terraform/plan.tfplan"
+$TF_BIN_PATH -chdir="$TF_DIR" plan -input=false -out="plan.tfplan"
 
 # symlink the plan output to the output directory
-ln -sfn "$PWD/$TF_DIR/.terraform/plan.tfplan" "$OUT_DIR/plan.tfplan"
+ln -sfn "$PWD/$TF_DIR/plan.tfplan" "$OUT_DIR/plan.tfplan"


### PR DESCRIPTION
- Creating `plan.tfplan` within the already symlinked `.terraform` directory creates a nested symlink, making a cyclic dependency. Instead, create `plan.tfplan` on the root.
- Pass the created `plan.tfplan` to the apply command.