### PR TITLE
feat: support tf backend definitions

### DIFF
--- a/tf_apply/defs.bzl
+++ b/tf_apply/defs.bzl
@@ -32,6 +32,7 @@ def tf_root_module(
 
     tf_vars(
         name = "{}.tfvars".format(name),
+        name_prefix = name,
         module = module,
         tfvars_deps = tfvars_deps,
         tfvars = tfvars,
@@ -48,6 +49,7 @@ def tf_root_module(
 
         tf_backend(
             name = "{}.backend".format(name),
+            name_prefix = name,
             type = backend_type,
             config = backend_config,
             visibility = visibility,

--- a/tf_apply/defs.bzl
+++ b/tf_apply/defs.bzl
@@ -3,14 +3,23 @@ This module provides macros and rules for initializing, planning, and applying T
 """
 
 load("@rules_tf//tf:def.bzl", _tf_module = "tf_module")
-load("@rules_tf_apply//tf_apply/rules:defs.bzl", _tf_apply = "tf_apply", _tf_init = "tf_init", _tf_plan = "tf_plan", _tf_vars = "tf_vars")
+load("@rules_tf_apply//tf_apply/rules:defs.bzl", _tf_apply = "tf_apply", _tf_init = "tf_init", _tf_plan = "tf_plan", _tf_vars = "tf_vars", _tf_backend = "tf_backend")
 
 tf_apply = _tf_apply
 tf_init = _tf_init
 tf_plan = _tf_plan
 tf_vars = _tf_vars
+tf_backend = _tf_backend
 
-def tf_module(name, **kwargs):
+def tf_root_module(
+    name,
+    module,
+    backend,
+    tfvars = {},
+    tfvars_deps = {},
+    tags = [],
+    visibility = ["//visibility:private"],
+):
     """
     Macro to create a Terraform module and apply rules for initialization, planning, and applying.
 
@@ -20,38 +29,53 @@ def tf_module(name, **kwargs):
     """
 
     # Remove tfvars_deps from kwargs to avoid passing it to _tf_module
-    tfvars_deps = kwargs.pop("tfvars_deps", {})
-    visibility = kwargs.get("visibility", ["//visibility:private"])
-
-    _tf_module(name = name, **kwargs)
 
     tf_vars(
-        name = "tfvars",
+        name = "{}.tfvars".format(name),
+        module = module,
         tfvars_deps = tfvars_deps,
-        module = native.package_relative_label(name),
+        tfvars = tfvars,
         visibility = visibility,
     )
 
+    if  backend:
+        # Backend is an object with one key, which is the backend type
+        if len(backend.keys()) > 1:
+            fail("backend attribute must have exactly one backend type")
+
+        backend_type = list(backend.keys())[0]
+        backend_config = backend[backend_type]
+
+        tf_backend(
+            name = "{}.backend".format(name),
+            type = backend_type,
+            config = backend_config,
+            visibility = visibility,
+        )
+
     tf_init(
-        name = "init",
-        module = native.package_relative_label(name),
-        tfvars = ":tfvars",
-        tags = kwargs.get("tags", []),
+        name = "{}.init".format(name),
+        module = module,
+        tfvars = ":{}.tfvars".format(name),
+        backend = ":{}.backend".format(name),
+        tags = tags,
         visibility = visibility,
     )
 
     tf_plan(
-        name = "plan",
-        module = native.package_relative_label(name),
-        tfvars = ":tfvars",
-        tags = kwargs.get("tags", []),
+        name = "{}.plan".format(name),
+        module = module,
+        tfvars = ":{}.tfvars".format(name),
+        backend = ":{}.backend".format(name),
+        tags = tags,
         visibility = visibility,
     )
 
     tf_apply(
-        name = "apply",
-        module = native.package_relative_label(name),
-        tfvars = ":tfvars",
-        tags = kwargs.get("tags", []),
+        name = "{}.apply".format(name),
+        module = module,
+        tfvars = ":{}.tfvars".format(name),
+        backend = ":{}.backend".format(name),
+        tags = tags,
         visibility = visibility,
     )

--- a/tf_apply/defs.bzl
+++ b/tf_apply/defs.bzl
@@ -2,8 +2,7 @@
 This module provides macros and rules for initializing, planning, and applying Terraform modules using rules_tf and rules_tf_apply.
 """
 
-load("@rules_tf//tf:def.bzl", _tf_module = "tf_module")
-load("@rules_tf_apply//tf_apply/rules:defs.bzl", _tf_apply = "tf_apply", _tf_init = "tf_init", _tf_plan = "tf_plan", _tf_vars = "tf_vars", _tf_backend = "tf_backend")
+load("@rules_tf_apply//tf_apply/rules:defs.bzl", _tf_apply = "tf_apply", _tf_backend = "tf_backend", _tf_init = "tf_init", _tf_plan = "tf_plan", _tf_vars = "tf_vars")
 
 tf_apply = _tf_apply
 tf_init = _tf_init
@@ -12,14 +11,13 @@ tf_vars = _tf_vars
 tf_backend = _tf_backend
 
 def tf_root_module(
-    name,
-    module,
-    backend,
-    tfvars = {},
-    tfvars_deps = {},
-    tags = [],
-    visibility = ["//visibility:private"],
-):
+        name,
+        module,
+        backend,
+        tfvars = {},
+        tfvars_deps = {},
+        tags = [],
+        visibility = ["//visibility:private"]):
     """
     Macro to create a Terraform module and apply rules for initialization, planning, and applying.
 
@@ -39,7 +37,7 @@ def tf_root_module(
         visibility = visibility,
     )
 
-    if  backend:
+    if backend:
         # Backend is an object with one key, which is the backend type
         if len(backend.keys()) > 1:
             fail("backend attribute must have exactly one backend type")

--- a/tf_apply/rules/defs.bzl
+++ b/tf_apply/rules/defs.bzl
@@ -162,7 +162,7 @@ def tf_init_impl(ctx):
         executable = init_script,
         runfiles = ctx.runfiles(files = deps, symlinks = {
             ctx.attr.module.label.package + "/bazel.auto.tfvars": tfvars_file,
-            ctx.attr.module.label.package + "/bazel.backend.tf": backend_deps[0] if backend_deps else None
+            ctx.attr.module.label.package + "/bazel.backend.tf": backend_deps[0] if backend_deps else None,
         }),
     )]
 
@@ -229,7 +229,7 @@ def tf_plan_impl(ctx):
         executable = plan_script,
         runfiles = ctx.runfiles(files = deps, symlinks = {
             ctx.attr.module.label.package + "/bazel.auto.tfvars": tfvars_file,
-            ctx.attr.module.label.package + "/bazel.backend.tf": backend_deps[0] if backend_deps else None
+            ctx.attr.module.label.package + "/bazel.backend.tf": backend_deps[0] if backend_deps else None,
         }),
     )]
 
@@ -295,7 +295,7 @@ def tf_apply_impl(ctx):
         executable = apply_script,
         runfiles = ctx.runfiles(files = deps, symlinks = {
             ctx.attr.module.label.package + "/bazel.auto.tfvars": tfvars_file,
-            ctx.attr.module.label.package + "/bazel.backend.tf": backend_deps[0] if backend_deps else None
+            ctx.attr.module.label.package + "/bazel.backend.tf": backend_deps[0] if backend_deps else None,
         }),
     )]
 

--- a/tf_apply/rules/defs.bzl
+++ b/tf_apply/rules/defs.bzl
@@ -41,8 +41,7 @@ def tf_vars_impl(ctx):
     Returns:
         DefaultInfo with the generated tfvars file.
     """
-
-    tfvars_file = ctx.actions.declare_file("{}.bazel.auto.tfvars".format(ctx.attr.module.label.name))
+    tfvars_file = ctx.actions.declare_file("{}.bazel.auto.tfvars".format(ctx.attr.name_prefix))
 
     tfvar_deps = []
     tfvars = dict(ctx.attr.tfvars)
@@ -63,6 +62,7 @@ def tf_vars_impl(ctx):
 tf_vars = rule(
     implementation = tf_vars_impl,
     attrs = {
+        "name_prefix": attr.string(),
         "tfvars_deps": attr.string_keyed_label_dict(
             default = {},
             doc = "Mapping of tfvars to labels containing the files.",
@@ -94,7 +94,7 @@ def tf_backend_impl(ctx):
         An empty list as this rule does not produce any outputs.
     """
 
-    backend_file = ctx.actions.declare_file("{}.bazel.backend.tf".format(ctx.attr.module.label.name))
+    backend_file = ctx.actions.declare_file("{}.bazel.backend.tf".format(ctx.attr.name_prefix))
     backend_content = 'terraform {{\n  backend "{}" {{\n'.format(ctx.attr.type)
     for key, value in ctx.attr.config.items():
         backend_content += '    {} = "{}"\n'.format(key, value)
@@ -110,6 +110,7 @@ def tf_backend_impl(ctx):
 tf_backend = rule(
     implementation = tf_backend_impl,
     attrs = {
+        "name_prefix": attr.string(),
         "type": attr.string(
             mandatory = True,
             doc = "The backend type.",

--- a/tf_apply/rules/defs.bzl
+++ b/tf_apply/rules/defs.bzl
@@ -42,7 +42,7 @@ def tf_vars_impl(ctx):
         DefaultInfo with the generated tfvars file.
     """
 
-    tfvars_file = ctx.actions.declare_file("bazel.auto.tfvars")
+    tfvars_file = ctx.actions.declare_file("{}.bazel.auto.tfvars".format(ctx.attr.module.label.name))
 
     tfvar_deps = []
     tfvars = dict(ctx.attr.tfvars)
@@ -94,7 +94,7 @@ def tf_backend_impl(ctx):
         An empty list as this rule does not produce any outputs.
     """
 
-    backend_file = ctx.actions.declare_file("bazel.backend.tf")
+    backend_file = ctx.actions.declare_file("{}.bazel.backend.tf".format(ctx.attr.module.label.name))
     backend_content = 'terraform {{\n  backend "{}" {{\n'.format(ctx.attr.type)
     for key, value in ctx.attr.config.items():
         backend_content += '    {} = "{}"\n'.format(key, value)

--- a/tf_apply/rules/tf_init.sh
+++ b/tf_apply/rules/tf_init.sh
@@ -25,6 +25,8 @@ rm -rf "$PWD/$TF_DIR/.terraform.lock.hcl"
 rm -rf "$OUT_DIR/.terraform"
 rm -rf "$OUT_DIR/.terraform.lock.hcl"
 
+echo "Running 'terraform init' in directory: $PWD/$TF_DIR"
+
 # Run terraform init
 $TF_BIN_PATH -chdir="$TF_DIR" init -input=false -plugin-dir="$TF_PLUGINS_DIR"
 


### PR DESCRIPTION
This is a major refactor of tf_init, plan and apply rules to and the tf_module macro.

- The tf_module macro is renamed to `tf_root_module` to signify that thees are executable root modules. It no longer internally create a `rules_tf::tf_module`. Instead `rules_tf::tf_module` is taken as a dep. This allows the separation of a general module and executable module.
- Introduces rules to define `tf_vars` and `tf_backend` to parameterize root module configuration.