### PR TITLE
chore: declare module version 0.1.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,6 +2,7 @@
 
 module(
     name = "rules_tf_apply",
+    version = "0.1.0",
     repo_name = "rules_tf_apply",
 )
 


### PR DESCRIPTION
## Summary

`rules_tf_apply` has no `version` in its `module()` and no git tags. This declares `version = "0.1.0"` so it can be tagged `v0.1.0` for a first release and consumed as a released `bazel_dep` version instead of a raw commit pin.

## Context

Part of standardizing `webrtc-sim` and `core-infra` on tagged releases of `rillanetwork/rules_tf` + `rillanetwork/rules_tf_apply`. Once merged I'll tag `v0.1.0` at this commit and cut a release, then both consumers pin `0.1.0`.