### PR TITLE
fix: plan JSON output symlink dangles (redirect vs -chdir)

### DIFF
--- a/tf_apply/rules/tf_plan.sh
+++ b/tf_apply/rules/tf_plan.sh
@@ -39,7 +39,7 @@ test -d "$TF_DIR/.terraform" && rm -rf "$TF_DIR/.terraform"
 test -f "$TF_DIR/.terraform.lock.hcl" && rm -rf "$TF_DIR/.terraform.lock.hcl"
 test -f "$TF_DIR/plan.tfplan" && rm -rf "$TF_DIR/plan.tfplan"
 if [ $TF_OUTPUT_JSON -eq 1 ]; then
-  test -f "$TF_DIR/plan.tfplan" && rm -rf "$TF_DIR/plan.tfplan.json"
+  test -f "$TF_DIR/plan.tfplan.json" && rm -rf "$TF_DIR/plan.tfplan.json"
 fi
 
 ln -sfn "$OUT_DIR/.terraform" "$TF_DIR/.terraform"
@@ -52,6 +52,6 @@ ln -sfn "$PWD/$TF_DIR/plan.tfplan" "$OUT_DIR/plan.tfplan"
 
 if [ $TF_OUTPUT_JSON -eq 1 ]; then
     # Transform the plan into json format, and symlink to the output directory
-    $TF_BIN_PATH -chdir="$TF_DIR" show -json "plan.tfplan" > "plan.tfplan.json"
+    $TF_BIN_PATH -chdir="$TF_DIR" show -json "plan.tfplan" > "$TF_DIR/plan.tfplan.json"
     ln -sfn "$PWD/$TF_DIR/plan.tfplan.json" "$OUT_DIR/plan.tfplan.json"
 fi


### PR DESCRIPTION
v0.2.0 (#9) added `output_json`, but the plan step wrote `plan.tfplan.json` via a shell redirect evaluated in the script CWD, while `-chdir` only moved terraform's working dir. The persisted `OUT_DIR/plan.tfplan.json` symlink pointed at `$TF_DIR/plan.tfplan.json` and dangled - the only real copy sat in the ephemeral runfiles CWD.

Redirect into `$TF_DIR` so the file lands where the symlink references (matching the `plan.tfplan` handling directly above), and fix the cleanup test that checked `plan.tfplan` but removed `plan.tfplan.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)