### PR TITLE
fix: make ruleset consumable by py_binary targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load("@package_metadata//licenses:defs.bzl", "license")
 load("@package_metadata//purl:purl.bzl", "purl")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
@@ -34,28 +33,4 @@ filegroup(
             "MODULE.bazel",
         ],
     visibility = ["//distro:__pkg__"],
-)
-
-# Buildifier
-
-buildifier(
-    name = "buildifier.fix",
-    exclude_patterns = [
-        "./.git/*",
-        "./node_modules/*",
-    ],
-    lint_mode = "fix",
-    lint_warnings = ["-all"],
-    mode = "fix",
-)
-
-buildifier(
-    name = "buildifier.check",
-    exclude_patterns = [
-        "./.git/*",
-        "./node_modules/*",
-    ],
-    lint_mode = "warn",
-    lint_warnings = ["-all"],
-    mode = "diff",
 )

--- a/lint/BUILD.bazel
+++ b/lint/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+
+# Buildifier lives in its own package (not the repo root) so the root BUILD
+# never loads @buildifier_prebuilt — a dev_dependency invisible to consumers.
+# The repo-wide `default_package_metadata = //:package_metadata` (REPO.bazel)
+# makes every consumer-built target implicitly depend on the root package, so
+# the root must stay loadable without dev-only repos.
+
+buildifier(
+    name = "buildifier.fix",
+    exclude_patterns = [
+        "./.git/*",
+        "./node_modules/*",
+    ],
+    lint_mode = "fix",
+    lint_warnings = ["-all"],
+    mode = "fix",
+)
+
+buildifier(
+    name = "buildifier.check",
+    exclude_patterns = [
+        "./.git/*",
+        "./node_modules/*",
+    ],
+    lint_mode = "warn",
+    lint_warnings = ["-all"],
+    mode = "diff",
+)

--- a/tools/list_modules.py
+++ b/tools/list_modules.py
@@ -242,6 +242,15 @@ def parse_target(target: str, manual_packages: set[str], affected: set[str], mod
 
 
 def main():
+    # `bazel run` executes from an ephemeral runfiles dir, so the bazel query
+    # and git subprocesses below (which use relative paths and expect to be at
+    # the workspace root) must be anchored there. BUILD_WORKSPACE_DIRECTORY is
+    # set by `bazel run`; when absent (direct script invocation / tests) we
+    # stay in the current dir, matching this tool's plain-script origin.
+    workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+    if workspace_dir:
+        os.chdir(workspace_dir)
+
     query_path = sys.argv[1] if len(sys.argv) > 1 else "//terraform/..."
     targets = list_plan_targets(query_path)
     manual_packages = list_manual_packages(query_path)


### PR DESCRIPTION
## What

Fixes two breakages that only surface when a **downstream** repo builds the shipped `py_binary` tools (`//tools:list_modules`, `//tools:run`) — not caught by this repo's own `bazel test //...` because dev_dependencies are visible to the root module and cwd is the workspace root.

1. **Root package loaded a dev-only repo.** `REPO.bazel` sets `repo(default_package_metadata = ["//:package_metadata"])`, so every consumer-built target implicitly depends on the root package. The root `BUILD.bazel` `load`ed `@buildifier_prebuilt` (a `dev_dependency`, invisible to consumers), so analysis aborted with *"No repository visible as '@buildifier_prebuilt'"*. Moved the `buildifier.fix`/`buildifier.check` targets to a new `//lint` package; the root now loads only non-dev `@package_metadata`. Target labels change `//:buildifier.*` → `//lint:buildifier.*` (nothing references them).

2. **`list_modules` didn't anchor its subprocesses.** It ran `bazel query`/`git` with no `cwd` — correct when invoked as a plain script from the repo root (core-infra's old usage), but `bazel run` executes from a runfiles dir, so `bazel query` exited 2. Now `chdir`s to `BUILD_WORKSPACE_DIRECTORY` when set (falls back to cwd for direct/test invocation).

## Verification

Validated end-to-end from a real consumer (webrtc-sim) via a temporary `local_path_override`: `bazel build //tools/terraform:{run,list_modules}` succeeds, and `list_modules` emits the 34-module cloud-neutral matrix with `module_package` correctly resolving thin roots. `bazel test //...` green in-repo.

## Follow-up

Supersedes v0.3.0 for consumers — needs a **v0.3.1** tag before webrtc-sim (#1674) / core-infra (#84) can adopt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
