### PR TITLE
chore: scrub internal repo name from MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-""" This file is used to define the module for the Peer Core repository."""
+"""Bazel module definition for rules_tf_apply."""
 
 module(
     name = "rules_tf_apply",


### PR DESCRIPTION
## What

The `MODULE.bazel` docstring described this module as belonging to an unrelated internal repository. Since this is a public repository, replace it with an accurate one-line description.

```diff
-""" This file is used to define the module for the Peer Core repository."""
+"""Bazel module definition for rules_tf_apply."""
```

## Test plan

- `grep -ri "peer.core"` over the tree returns nothing further - this was the only occurrence.
- `bazel mod graph --lockfile_mode=error` resolves cleanly; `MODULE.bazel.lock` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)